### PR TITLE
VCI-315: vc-build - Update target

### DIFF
--- a/src/VirtoCommerce.Build/PlatformTools/Build.PackageManager.cs
+++ b/src/VirtoCommerce.Build/PlatformTools/Build.PackageManager.cs
@@ -199,7 +199,7 @@ namespace VirtoCommerce.Build
                 var bakFileName = new StringBuilder("appsettings.")
                     .Append(DateTime.Now.ToString("MMddyyHHmmss"))
                     .Append(".bak");
-                var destinationSettingsPath = Path.Join(Path.GetDirectoryName(AppsettingsPath), bakFileName.ToString());
+                var destinationSettingsPath = !Force ? AppsettingsPath : Path.Join(Path.GetDirectoryName(AppsettingsPath), bakFileName.ToString());
                 FileSystemTasks.MoveFile(tempFile, destinationSettingsPath, FileExistsPolicy.Overwrite);
 
                 // there is a way to merge two appsettings.json (old version and new one) leaving the old settings,
@@ -464,15 +464,11 @@ namespace VirtoCommerce.Build
 
         private static void AppsettingsMessage(string bakFileName)
         {
-            var colorBackup = Console.ForegroundColor;
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine();
-            Console.WriteLine("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-            Console.WriteLine("+ appsettings.json has been updated. Maybe there are new settings there.  +");
-            Console.WriteLine($"+ The old version of the file with the name {bakFileName}  +");
-            Console.WriteLine("+ has been restored to the same directory.                                +");
-            Console.WriteLine("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-            Console.ForegroundColor = colorBackup;
+            Log.Information("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+            Log.Information("+ appsettings.json has been updated. Maybe there are new settings there.  +");
+            Log.Information($"+ The old version of the file with the name {bakFileName}  +");
+            Log.Information("+ has been restored to the same directory.                                +");
+            Log.Information("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
         }
     }
 }

--- a/src/VirtoCommerce.Build/PlatformTools/Build.PackageManager.cs
+++ b/src/VirtoCommerce.Build/PlatformTools/Build.PackageManager.cs
@@ -202,8 +202,6 @@ namespace VirtoCommerce.Build
                 var destinationSettingsPath = !Force ? AppsettingsPath : Path.Join(Path.GetDirectoryName(AppsettingsPath), bakFileName.ToString());
                 FileSystemTasks.MoveFile(tempFile, destinationSettingsPath, FileExistsPolicy.Overwrite);
 
-                // there is a way to merge two appsettings.json (old version and new one) leaving the old settings,
-                // but there will no comments in the final file
                 AppsettingsMessage(bakFileName.ToString());
             }
         }

--- a/src/VirtoCommerce.Build/PlatformTools/Build.PackageManager.cs
+++ b/src/VirtoCommerce.Build/PlatformTools/Build.PackageManager.cs
@@ -199,8 +199,12 @@ namespace VirtoCommerce.Build
                 var bakFileName = new StringBuilder("appsettings.")
                     .Append(DateTime.Now.ToString("MMddyyHHmmss"))
                     .Append(".bak");
-                var destinationSettingsPath = !Force ? AppsettingsPath : Path.Join(Path.GetDirectoryName(AppsettingsPath), bakFileName.ToString());
+                var destinationSettingsPath = Path.Join(Path.GetDirectoryName(AppsettingsPath), bakFileName.ToString());
                 FileSystemTasks.MoveFile(tempFile, destinationSettingsPath, FileExistsPolicy.Overwrite);
+
+                // there is a way to merge two appsettings.json (old version and new one) leaving the old settings,
+                // but there will no comments in the final file
+                AppsettingsMessage(bakFileName.ToString());
             }
         }
 
@@ -456,6 +460,19 @@ namespace VirtoCommerce.Build
                 githubModules.Add(new ModuleItem(manifest.Id, manifest.Version));
             });
             return packageManifest;
+        }
+
+        private static void AppsettingsMessage(string bakFileName)
+        {
+            var colorBackup = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine();
+            Console.WriteLine("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+            Console.WriteLine("+ appsettings.json has been updated. Maybe there are new settings there.  +");
+            Console.WriteLine($"+ The old version of the file with the name {bakFileName}  +");
+            Console.WriteLine("+ has been restored to the same directory.                                +");
+            Console.WriteLine("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+            Console.ForegroundColor = colorBackup;
         }
     }
 }

--- a/src/VirtoCommerce.Build/PlatformTools/Build.PackageManager.cs
+++ b/src/VirtoCommerce.Build/PlatformTools/Build.PackageManager.cs
@@ -202,7 +202,14 @@ namespace VirtoCommerce.Build
                 var destinationSettingsPath = !Force ? AppsettingsPath : Path.Join(Path.GetDirectoryName(AppsettingsPath), bakFileName.ToString());
                 FileSystemTasks.MoveFile(tempFile, destinationSettingsPath, FileExistsPolicy.Overwrite);
 
-                AppsettingsMessage(bakFileName.ToString());
+                if (Force)
+                {
+                    Log.Information($"The old appsettings.json was saved as {bakFileName}");
+                }
+                else
+                {
+                    Log.Information($"appsettings.json was restored");
+                }
             }
         }
 
@@ -458,15 +465,6 @@ namespace VirtoCommerce.Build
                 githubModules.Add(new ModuleItem(manifest.Id, manifest.Version));
             });
             return packageManifest;
-        }
-
-        private static void AppsettingsMessage(string bakFileName)
-        {
-            Log.Information("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-            Log.Information("+ appsettings.json has been updated. Maybe there are new settings there.  +");
-            Log.Information($"+ The old version of the file with the name {bakFileName}  +");
-            Log.Information("+ has been restored to the same directory.                                +");
-            Log.Information("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
         }
     }
 }


### PR DESCRIPTION
There is a way to merge two appsettings.json (old version and new one) leaving the old settings. But there will no comments in the final file.

Тow I have removed the check for the "force" command and the appsettings file.json overwrites the original version, but leaves a backup file with the extension ".bak". A message about this is displayed to the user.