### PR TITLE
VCST-3739: Update platform to 3.854.13

### DIFF
--- a/src/VirtoCommerce.Build/VirtoCommerce.Build.csproj
+++ b/src/VirtoCommerce.Build/VirtoCommerce.Build.csproj
@@ -59,13 +59,13 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Cli" Version="6.0.0">
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Virtocommerce.Platform.Core" Version="3.854.3" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.854.3" />
-    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.854.3" />
-    <PackageReference Include="VirtoCommerce.Platform.DistributedLock" Version="3.854.3" />
+    <PackageReference Include="Virtocommerce.Platform.Core" Version="3.854.13" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.854.13" />
+    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.854.13" />
+    <PackageReference Include="VirtoCommerce.Platform.DistributedLock" Version="3.854.13" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup> 
     <NukeExternalFiles Include="**\*.*.ext" Exclude="bin\**;obj\**" />
     <Compile Remove="artifacts\**" />
     <Compile Remove="Properties\**" />


### PR DESCRIPTION
fix: Update platform to add .zip extension and copy into app_data\modules folder. For example, it allows Azure Monitor access to TraceUpload.zip.