### PR TITLE
VCST-4730: BuildCustomApps tool allows to build multiple apps

### DIFF
--- a/src/VirtoCommerce.Build/Build.cs
+++ b/src/VirtoCommerce.Build/Build.cs
@@ -341,6 +341,7 @@ internal partial class Build : NukeBuild
                 if (ThereAreCustomApps)
                 {
                     ignorePaths.Add(WebProject.Directory / "App");
+                    ignorePaths.Add(WebProject.Directory / "Apps");
                 }
             }
 

--- a/src/VirtoCommerce.Build/PlatformTools/Build.ModuleWithCustomApp.cs
+++ b/src/VirtoCommerce.Build/PlatformTools/Build.ModuleWithCustomApp.cs
@@ -7,6 +7,9 @@ namespace VirtoCommerce.Build
 {
     internal partial class Build
     {
+        private static AbsolutePath AppsDirectory => WebProject?.Directory / "Apps";
+        private static AbsolutePath AppDirectory => WebProject?.Directory / "App";
+
         public static bool ThereAreCustomApps => IsModule && ModuleManifest?.Apps?.Length > 0;
 
         public Target CompressWithCustomApp => _ => _
@@ -22,26 +25,51 @@ namespace VirtoCommerce.Build
             .OnlyWhenDynamic(() => ThereAreCustomApps)
             .Executes(() =>
             {
-                if (WebProject != null && ModuleManifest.Apps.Length > 0)
-                {
-                    foreach (var app in ModuleManifest.Apps)
-                    {
-                        if (!(WebProject.Directory / "App" / "package.json").FileExists())
-                        {
-                            continue;
-                        }
+                var apps = ModuleManifest.Apps;
+                var yarn = ToolResolver.GetPathTool("yarn");
 
-                        var chmod = ToolResolver.GetPathTool("yarn");
-                        chmod.Invoke("install", WebProject.Directory / "App");
-                        chmod.Invoke("build", WebProject.Directory / "App");
-                        var sourceDirectory = WebProject.Directory / "App" / "dist";
-                        sourceDirectory.Copy(WebProject.Directory / "Content" / app.Id, ExistsPolicy.MergeAndOverwrite);
-                    }
-                }
-                else
+                foreach (var app in apps)
                 {
-                    Log.Information("Nothing to build.");
+                    var appFolder = ResolveAppFolder(app.Id, apps.Length > 1);
+                    if (appFolder == null)
+                    {
+                        Log.Warning("Skipping app {AppId}: no folder with package.json found.", app.Id);
+                        continue;
+                    }
+
+                    var distDirectory = appFolder / "dist";
+                    distDirectory.DeleteDirectory();
+                    Log.Information("Building custom app: {AppId} from {Folder}", app.Id, appFolder);
+                    yarn.Invoke("install", appFolder);
+                    yarn.Invoke("build", appFolder);
+                    var targetDirectory = WebProject.Directory / "Content" / app.Id;
+                    targetDirectory.DeleteDirectory();
+                    distDirectory.Copy(targetDirectory, ExistsPolicy.MergeAndOverwrite);
                 }
             });
+
+        private static AbsolutePath ResolveAppFolder(string appId, bool multipleApps)
+        {
+            // Multiple apps — only Apps/{id} is supported
+            if (multipleApps)
+            {
+                var folder = AppsDirectory / appId;
+                return (folder / "package.json").FileExists() ? folder : null;
+            }
+
+            // Single app — prefer Apps/{id}, fallback to legacy App/
+            var appsSubfolder = AppsDirectory / appId;
+            if ((appsSubfolder / "package.json").FileExists())
+            {
+                return appsSubfolder;
+            }
+
+            if ((AppDirectory / "package.json").FileExists())
+            {
+                return AppDirectory;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/VirtoCommerce.Build/PlatformTools/Build.ModuleWithCustomApp.cs
+++ b/src/VirtoCommerce.Build/PlatformTools/Build.ModuleWithCustomApp.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
@@ -26,23 +27,24 @@ namespace VirtoCommerce.Build
             .Executes(() =>
             {
                 var apps = ModuleManifest.Apps;
+                var multipleApps = apps.Length > 1;
                 var yarn = ToolResolver.GetPathTool("yarn");
 
-                foreach (var app in apps)
+                foreach (var appId in apps.Select(a => a.Id))
                 {
-                    var appFolder = ResolveAppFolder(app.Id, apps.Length > 1);
+                    var appFolder = ResolveAppFolder(appId, multipleApps);
                     if (appFolder == null)
                     {
-                        Log.Warning("Skipping app {AppId}: no folder with package.json found.", app.Id);
+                        Log.Warning("Skipping app {AppId}: no folder with package.json found.", appId);
                         continue;
                     }
 
                     var distDirectory = appFolder / "dist";
                     distDirectory.DeleteDirectory();
-                    Log.Information("Building custom app: {AppId} from {Folder}", app.Id, appFolder);
+                    Log.Information("Building custom app: {AppId} from {Folder}", appId, appFolder);
                     yarn.Invoke("install", appFolder);
                     yarn.Invoke("build", appFolder);
-                    var targetDirectory = WebProject.Directory / "Content" / app.Id;
+                    var targetDirectory = WebProject.Directory / "Content" / appId;
                     targetDirectory.DeleteDirectory();
                     distDirectory.Copy(targetDirectory, ExistsPolicy.MergeAndOverwrite);
                 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the custom-app build/publish pipeline and filesystem conventions; mis-detection of app folders or cleaning could break CI builds for modules with custom apps.
> 
> **Overview**
> **Custom app builds now support multiple apps.** `BuildCustomApp` iterates `module.manifest` apps and builds each via `yarn` from a resolved folder (multiple apps require `Apps/{appId}`, single app prefers `Apps/{appId}` with fallback to legacy `App/`).
> 
> Build output handling was updated to clean and re-copy each app’s `dist` into `Content/{appId}`, and the `Clean` target now also preserves the `Apps/` directory when custom apps are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b94245d2d7c7254f7a485744ce81ec29c1e811fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->