### PR TITLE
Use ni for custom app builds with optional package manager override

### DIFF
--- a/src/VirtoCommerce.Build/PlatformTools/Build.ModuleWithCustomApp.cs
+++ b/src/VirtoCommerce.Build/PlatformTools/Build.ModuleWithCustomApp.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Nuke.Common;
 using Nuke.Common.IO;
@@ -8,6 +10,20 @@ namespace VirtoCommerce.Build
 {
     internal partial class Build
     {
+        private const string DefaultCustomAppOutputFolder = "dist";
+
+        [Parameter("Package manager executable for custom apps (e.g. yarn, pnpm, npm, bun). When unset, uses ni via npx for auto-detection. When set, both --custom-app-install-command and --custom-app-build-command are required.", Name = "CustomAppPackageManager")]
+        public static string CustomAppPackageManager { get; set; }
+
+        [Parameter("Install command (passed to the package manager) for custom apps. Required when --custom-app-package-manager is set.", Name = "CustomAppInstallCommand")]
+        public static string CustomAppInstallCommand { get; set; }
+
+        [Parameter("Build command (passed to the package manager) for custom apps. Required when --custom-app-package-manager is set.", Name = "CustomAppBuildCommand")]
+        public static string CustomAppBuildCommand { get; set; }
+
+        [Parameter("Custom app build output folder, relative to the app folder. Default: 'dist'.", Name = "CustomAppOutputFolder")]
+        public static string CustomAppOutputFolder { get; set; }
+
         private static AbsolutePath AppsDirectory => WebProject?.Directory / "Apps";
         private static AbsolutePath AppDirectory => WebProject?.Directory / "App";
 
@@ -28,7 +44,26 @@ namespace VirtoCommerce.Build
             {
                 var apps = ModuleManifest.Apps;
                 var multipleApps = apps.Length > 1;
-                var yarn = ToolResolver.GetPathTool("yarn");
+                var outputFolder = string.IsNullOrWhiteSpace(CustomAppOutputFolder) ? DefaultCustomAppOutputFolder : CustomAppOutputFolder;
+
+                var packageManagerIsSet = !string.IsNullOrWhiteSpace(CustomAppPackageManager);
+                if (packageManagerIsSet)
+                {
+                    Assert.NotNullOrWhiteSpace(CustomAppInstallCommand, $"--custom-app-install-command is required when --custom-app-package-manager is set (got '{CustomAppPackageManager}').");
+                    Assert.NotNullOrWhiteSpace(CustomAppBuildCommand, $"--custom-app-build-command is required when --custom-app-package-manager is set (got '{CustomAppPackageManager}').");
+                }
+                else if (!string.IsNullOrWhiteSpace(CustomAppInstallCommand) || !string.IsNullOrWhiteSpace(CustomAppBuildCommand))
+                {
+                    Assert.Fail("--custom-app-package-manager is required when --custom-app-install-command or --custom-app-build-command is set (commands use package-manager-specific syntax that cannot be passed to ni).");
+                }
+
+                var packageManagerTool = ToolResolver.GetPathTool(packageManagerIsSet ? CustomAppPackageManager : "npx");
+                var installArguments = packageManagerIsSet ? CustomAppInstallCommand : "-y @antfu/ni --frozen";
+                var buildArguments = packageManagerIsSet ? CustomAppBuildCommand : "-y -p @antfu/ni nr build";
+                var env = new Dictionary<string, string>(EnvironmentInfo.Variables, StringComparer.OrdinalIgnoreCase)
+                {
+                    ["COREPACK_ENABLE_DOWNLOAD_PROMPT"] = "0",
+                };
 
                 foreach (var appId in apps.Select(a => a.Id))
                 {
@@ -39,11 +74,11 @@ namespace VirtoCommerce.Build
                         continue;
                     }
 
-                    var distDirectory = appFolder / "dist";
+                    var distDirectory = appFolder / outputFolder;
                     distDirectory.DeleteDirectory();
-                    Log.Information("Building custom app: {AppId} from {Folder}", appId, appFolder);
-                    yarn.Invoke("install", appFolder);
-                    yarn.Invoke("build", appFolder);
+                    Log.Information("Building custom app: {AppId} from {Folder} (output: {OutputFolder})", appId, appFolder, outputFolder);
+                    packageManagerTool.Invoke(installArguments, appFolder, env);
+                    packageManagerTool.Invoke(buildArguments, appFolder, env);
                     var targetDirectory = WebProject.Directory / "Content" / appId;
                     targetDirectory.DeleteDirectory();
                     distDirectory.Copy(targetDirectory, ExistsPolicy.MergeAndOverwrite);

--- a/src/VirtoCommerce.Build/PlatformTools/Build.ModuleWithCustomApp.cs
+++ b/src/VirtoCommerce.Build/PlatformTools/Build.ModuleWithCustomApp.cs
@@ -81,7 +81,7 @@ namespace VirtoCommerce.Build
                 : (ToolResolver.GetPathTool(CustomAppPackageManager), CustomAppInstallCommand, CustomAppBuildCommand);
         }
 
-        private static IReadOnlyDictionary<string, string> BuildCustomAppEnvironment()
+        private static Dictionary<string, string> BuildCustomAppEnvironment()
         {
             return new Dictionary<string, string>(EnvironmentInfo.Variables, StringComparer.OrdinalIgnoreCase)
             {
@@ -89,7 +89,7 @@ namespace VirtoCommerce.Build
             };
         }
 
-        private static void BuildSingleCustomApp(string appId, bool multipleApps, string outputFolder, Tool packageManagerTool, string installArguments, string buildArguments, IReadOnlyDictionary<string, string> environment)
+        private static void BuildSingleCustomApp(string appId, bool multipleApps, string outputFolder, Tool packageManagerTool, string installArguments, string buildArguments, Dictionary<string, string> environment)
         {
             var appFolder = ResolveAppFolder(appId, multipleApps);
             if (appFolder == null)

--- a/src/VirtoCommerce.Build/PlatformTools/Build.ModuleWithCustomApp.cs
+++ b/src/VirtoCommerce.Build/PlatformTools/Build.ModuleWithCustomApp.cs
@@ -40,50 +40,73 @@ namespace VirtoCommerce.Build
         public Target BuildCustomApp => _ => _
             .After(WebPackBuild)
             .OnlyWhenDynamic(() => ThereAreCustomApps)
-            .Executes(() =>
+            .Executes(BuildAllCustomApps);
+
+        private static void BuildAllCustomApps()
+        {
+            ValidateCustomAppParameters();
+            var (packageManagerTool, installArguments, buildArguments) = ResolveCustomAppCommands();
+            var outputFolder = string.IsNullOrWhiteSpace(CustomAppOutputFolder)
+                ? DefaultCustomAppOutputFolder
+                : CustomAppOutputFolder;
+            var environment = BuildCustomAppEnvironment();
+            var apps = ModuleManifest.Apps;
+            var multipleApps = apps.Length > 1;
+
+            foreach (var appId in apps.Select(application => application.Id))
             {
-                var apps = ModuleManifest.Apps;
-                var multipleApps = apps.Length > 1;
-                var outputFolder = string.IsNullOrWhiteSpace(CustomAppOutputFolder) ? DefaultCustomAppOutputFolder : CustomAppOutputFolder;
+                BuildSingleCustomApp(appId, multipleApps, outputFolder, packageManagerTool, installArguments, buildArguments, environment);
+            }
+        }
 
-                var packageManagerIsSet = !string.IsNullOrWhiteSpace(CustomAppPackageManager);
-                if (packageManagerIsSet)
-                {
-                    Assert.NotNullOrWhiteSpace(CustomAppInstallCommand, $"--custom-app-install-command is required when --custom-app-package-manager is set (got '{CustomAppPackageManager}').");
-                    Assert.NotNullOrWhiteSpace(CustomAppBuildCommand, $"--custom-app-build-command is required when --custom-app-package-manager is set (got '{CustomAppPackageManager}').");
-                }
-                else if (!string.IsNullOrWhiteSpace(CustomAppInstallCommand) || !string.IsNullOrWhiteSpace(CustomAppBuildCommand))
-                {
-                    Assert.Fail("--custom-app-package-manager is required when --custom-app-install-command or --custom-app-build-command is set (commands use package-manager-specific syntax that cannot be passed to ni).");
-                }
+        private static void ValidateCustomAppParameters()
+        {
+            if (!string.IsNullOrWhiteSpace(CustomAppPackageManager))
+            {
+                Assert.NotNullOrWhiteSpace(CustomAppInstallCommand, $"--custom-app-install-command is required when --custom-app-package-manager is set (got '{CustomAppPackageManager}').");
+                Assert.NotNullOrWhiteSpace(CustomAppBuildCommand, $"--custom-app-build-command is required when --custom-app-package-manager is set (got '{CustomAppPackageManager}').");
+                return;
+            }
 
-                var packageManagerTool = ToolResolver.GetPathTool(packageManagerIsSet ? CustomAppPackageManager : "npx");
-                var installArguments = packageManagerIsSet ? CustomAppInstallCommand : "-y @antfu/ni --frozen";
-                var buildArguments = packageManagerIsSet ? CustomAppBuildCommand : "-y -p @antfu/ni nr build";
-                var env = new Dictionary<string, string>(EnvironmentInfo.Variables, StringComparer.OrdinalIgnoreCase)
-                {
-                    ["COREPACK_ENABLE_DOWNLOAD_PROMPT"] = "0",
-                };
+            if (!string.IsNullOrWhiteSpace(CustomAppInstallCommand) || !string.IsNullOrWhiteSpace(CustomAppBuildCommand))
+            {
+                Assert.Fail("--custom-app-package-manager is required when --custom-app-install-command or --custom-app-build-command is set (commands use package-manager-specific syntax that cannot be passed to ni).");
+            }
+        }
 
-                foreach (var appId in apps.Select(a => a.Id))
-                {
-                    var appFolder = ResolveAppFolder(appId, multipleApps);
-                    if (appFolder == null)
-                    {
-                        Log.Warning("Skipping app {AppId}: no folder with package.json found.", appId);
-                        continue;
-                    }
+        private static (Tool tool, string installArguments, string buildArguments) ResolveCustomAppCommands()
+        {
+            return string.IsNullOrWhiteSpace(CustomAppPackageManager)
+                ? (ToolResolver.GetPathTool("npx"), "-y @antfu/ni --frozen", "-y -p @antfu/ni nr build")
+                : (ToolResolver.GetPathTool(CustomAppPackageManager), CustomAppInstallCommand, CustomAppBuildCommand);
+        }
 
-                    var distDirectory = appFolder / outputFolder;
-                    distDirectory.DeleteDirectory();
-                    Log.Information("Building custom app: {AppId} from {Folder} (output: {OutputFolder})", appId, appFolder, outputFolder);
-                    packageManagerTool.Invoke(installArguments, appFolder, env);
-                    packageManagerTool.Invoke(buildArguments, appFolder, env);
-                    var targetDirectory = WebProject.Directory / "Content" / appId;
-                    targetDirectory.DeleteDirectory();
-                    distDirectory.Copy(targetDirectory, ExistsPolicy.MergeAndOverwrite);
-                }
-            });
+        private static IReadOnlyDictionary<string, string> BuildCustomAppEnvironment()
+        {
+            return new Dictionary<string, string>(EnvironmentInfo.Variables, StringComparer.OrdinalIgnoreCase)
+            {
+                ["COREPACK_ENABLE_DOWNLOAD_PROMPT"] = "0",
+            };
+        }
+
+        private static void BuildSingleCustomApp(string appId, bool multipleApps, string outputFolder, Tool packageManagerTool, string installArguments, string buildArguments, IReadOnlyDictionary<string, string> environment)
+        {
+            var appFolder = ResolveAppFolder(appId, multipleApps);
+            if (appFolder == null)
+            {
+                Log.Warning("Skipping app {AppId}: no folder with package.json found.", appId);
+                return;
+            }
+
+            var distDirectory = appFolder / outputFolder;
+            distDirectory.DeleteDirectory();
+            Log.Information("Building custom app: {AppId} from {Folder} (output: {OutputFolder})", appId, appFolder, outputFolder);
+            packageManagerTool.Invoke(installArguments, appFolder, environment);
+            packageManagerTool.Invoke(buildArguments, appFolder, environment);
+            var targetDirectory = WebProject.Directory / "Content" / appId;
+            targetDirectory.DeleteDirectory();
+            distDirectory.Copy(targetDirectory, ExistsPolicy.MergeAndOverwrite);
+        }
 
         private static AbsolutePath ResolveAppFolder(string appId, bool multipleApps)
         {


### PR DESCRIPTION
## What changed

`BuildCustomApp` previously called `yarn install` and `yarn build` directly. It now delegates to [`ni`](https://github.com/antfu-collective/ni), which auto-detects the project's package manager and forwards the same intent to whichever one the project actually uses. A set of opt-in parameters is added for projects that need full control.

## Glossary (for non-frontend folks)

| Term | What it is |
|---|---|
| Package manager (PM) | Tool that installs JS dependencies and runs project scripts. Today's options: `yarn`, `pnpm`, `npm`, `bun`. Each writes its own lockfile (`yarn.lock`, `pnpm-lock.yaml`, `package-lock.json`, `bun.lockb`) and has slightly different command syntax. |
| `package.json` | Project manifest. Lists dependencies and named scripts (e.g. `build`, `test`). Also can declare which PM the project expects via the `packageManager` field. |
| Lockfile | Records exact resolved dependency versions so installs are reproducible. |
| `corepack` | Bundled with Node.js. When enabled, it reads `packageManager` from `package.json` and downloads/runs the exact PM version pinned there, transparently. |
| `ni` | Thin wrapper around all four PMs. Reads the lockfile + `packageManager` field to figure out which PM the project uses, then forwards your intent (install / run build / etc.) to that PM with the right syntax. |
| `--frozen` | "Don't touch the lockfile." Fails the build if the lockfile is out of date with `package.json` instead of silently updating it. The standard CI safeguard against drift. |

## Why ni

Before, vc-build only supported yarn-based custom apps. vc-shell (the framework most VC modules build on top of) is still yarn-based and does not change here. The point of ni is to **widen the set of supported frameworks** so a module that prefers another PM is no longer locked out:

| Project shape | Before this PR | After this PR |
|---|---|---|
| vc-shell-based apps (yarn) | Worked | Works (no change in behavior) |
| Apps with `pnpm-lock.yaml` | Failed (no yarn.lock) | Works |
| Apps with `package-lock.json` (npm) | Failed | Works |
| Apps with `bun.lockb` | Failed | Works |
| Anything corepack-pinned | Worked only if a system yarn happened to match | Works correctly — corepack-pinned PM version is honored |

## Default flow (the 99% case)

For any app that follows the conventional `build` script and outputs to `dist/`, vc-build needs zero configuration. The target now runs:

| Step | Command | Effect |
|---|---|---|
| Install | `npx -y @antfu/ni --frozen` | Detects PM, runs `<pm> install` with frozen-lockfile semantics. CI fails loud if `package.json` and the lockfile have drifted apart. |
| Build | `npx -y -p @antfu/ni nr build` | Runs the project's `build` script via the detected PM. |
| Copy | (NUKE) | Copies `<app>/dist/` into `<module>/Content/<appId>/`. |

`COREPACK_ENABLE_DOWNLOAD_PROMPT=0` is set on the child env so first-time corepack downloads do not hang CI waiting for an interactive `y/N`.

## Custom flow (the 1% case)

For apps that use non-default scripts, a non-`dist` output folder, or projects where teams prefer to skip the `npx ni` cold-start (it fetches `@antfu/ni` from the npm registry on each clean run), four parameters are added:

| Parameter | Purpose | Default |
|---|---|---|
| `--custom-app-package-manager` | PM executable to invoke directly (`yarn`, `pnpm`, `npm`, `bun`, …) | unset → use ni |
| `--custom-app-install-command` | Install args passed to that PM (e.g. `install --immutable`, `ci`) | required when PM is set |
| `--custom-app-build-command` | Build args passed to that PM (e.g. `run build:prod`) | required when PM is set |
| `--custom-app-output-folder` | Output dir relative to the app folder | `dist` |

Install/build syntax differs across PMs (yarn `install --immutable` vs npm `ci` vs pnpm `install --frozen-lockfile`), so vc-build cannot pick a sensible default for them once a PM is named. Validation runs at target start:

- Setting `--custom-app-package-manager` requires both command parameters.
- Setting either command parameter requires `--custom-app-package-manager` (the commands have PM-specific syntax).
- Otherwise nothing else is mandatory and ni handles everything.

This matches the codebase's existing "conditional required" idiom (see `CloudToken` in `Build.SaaS.cs`) — `Assert` calls inside the target body produce contextual error messages.

## Test plan

End-to-end against a fresh clone of [vc-module-news](https://github.com/VirtoCommerce/vc-module-news) (vite + yarn 4.9.1 via corepack):

- [x] No parameters — `BuildCustomApp` succeeds via ni in ~59s; artifacts copied to `Content/vc-news/`.
- [x] `--custom-app-package-manager yarn --custom-app-install-command "install --immutable" --custom-app-build-command "run build"` — succeeds in ~37s (skips the `npx ni` registry hit).
- [x] `--custom-app-package-manager yarn` only — fails in <1s: `--custom-app-install-command is required when --custom-app-package-manager is set (got 'yarn').`
- [x] `--custom-app-install-command "install --immutable"` only — fails in <1s: `--custom-app-package-manager is required when --custom-app-install-command or --custom-app-build-command is set`.
- [x] `dotnet build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)