### PR TITLE
VCST-5373: Use NuGet trusted publishing

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -11,12 +11,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.200.20
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.42
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.200.20
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.42
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -95,7 +95,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata, publish-nuget]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.200.20
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.42
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -39,18 +39,71 @@ jobs:
       id: changelog
       uses: VirtoCommerce/vc-github-actions/changelog-generator@master
 
+  # Trusted Publishing: mint the OIDC key and push in ONE job. needs get-metadata too, so a metadata
+  # failure blocks the push (else the package publishes while publish-github-release is skipped).
+  # The push can't move into the cross-repo publish-github.yml (job_workflow_ref mismatch — #6/#9).
+  publish-nuget:
+    needs: [build, test, get-metadata]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+    steps:
+      - name: Install VirtoCommerce.GlobalTool
+        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Reuse the package built by the `build` job (same cache key/path it wrote).
+      - name: Get package from cache
+        id: restore-build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ needs.build.outputs.packageFullKey }}
+          path: |
+            ${{ github.workspace }}/artifacts
+            ${{ github.workspace }}/publish
+
+      - name: Exit if cache not restored
+        if: steps.restore-build.outputs.cache-hit != 'true'
+        env:
+          FULL_KEY: ${{ needs.build.outputs.packageFullKey }}
+        run: |
+          echo "::error::Package cache not found for key ${FULL_KEY}"
+          exit 1
+
+      - name: NuGet login (OIDC -> temp API key)
+        id: nuget_login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          # nuget.org user that created the trust policy (shared service account). Hardcoded because
+          # private repos can't read org-level Actions variables in the current plan.
+          user: virto
+
+      - name: Publish Nuget
+        uses: VirtoCommerce/vc-github-actions/publish-nuget@master
+        with:
+          skipString: 'Clean+Restore+Compile+Test+Pack'
+        env:
+          NUGET_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
+
+  # GitHub release only. forceNuget: false — the push is done by publish-nuget above.
   publish-github-release:
     needs:
-      [build, test, get-metadata]
+      [build, test, get-metadata, publish-nuget]
     uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.200.20
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'
       incrementPatch: ${{ github.event.inputs.incrementPatch }}
+      forceNuget: false
 
     secrets:
       envPAT: ${{ secrets.GITHUB_TOKEN }}
-      nugetKey: ${{ secrets.NUGET_KEY }}
 
   increment-version:
     needs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,14 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    # id-token: write lets NuGet/login mint a short-lived OIDC key (Trusted Publishing).
+    # contents: write for the GitHub release step.
+    permissions:
+      contents: write
+      id-token: write
     env:
       SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
       GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
-      NUGET_KEY: ${{ secrets.NUGET_KEY }}
       BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
 
     steps:
@@ -85,9 +89,21 @@ jobs:
         with:
           login: ${{secrets.SONAR_TOKEN}}
 
+      # Trusted Publishing: swap the GitHub OIDC token for a ~1h nuget.org key, minted right before push.
+      - name: NuGet login (OIDC -> temp API key)
+        if: ${{ (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') && github.event_name != 'workflow_dispatch' }}
+        id: nuget_login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          # nuget.org user that created the trust policy (shared service account). Hardcoded because
+          # private repos can't read org-level Actions variables in the current plan.
+          user: virto
+
       - name: Publish Nuget
         if: ${{ (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') && github.event_name != 'workflow_dispatch' }}
         uses: VirtoCommerce/vc-github-actions/publish-nuget@master
+        env:
+          NUGET_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
 
       - name: Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how packages are authenticated and published to nuget.org; misconfigured OIDC trust or cache misses in hotfix would block releases, but scope is limited to workflow YAML.
> 
> **Overview**
> Replaces **long-lived `NUGET_KEY` secrets** with **NuGet Trusted Publishing**: workflows mint a short-lived API key via **`NuGet/login`** using GitHub OIDC (`id-token: write`).
> 
> In **`main.yml`**, the global `NUGET_KEY` env is removed; publish runs only after the OIDC login step and passes `NUGET_API_KEY` into `publish-nuget`.
> 
> In **`hotfix.yml`**, reusable VirtoCommerce workflows are bumped to **`v3.800.42`**. NuGet push moves into a dedicated **`publish-nuget`** job (restore build artifacts from cache, OIDC login, publish with pack skipped). **`publish-github-release`** now waits on that job, sets **`forceNuget: false`**, and drops the **`nugetKey`** secret so releases no longer double-push packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec4ee46c0c638eb2d4e765500d83375f5429515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->