### PR TITLE
VCST-5248: Bump action versions

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -26,7 +26,7 @@ jobs:
       envPAT: ${{ secrets.REPO_TOKEN }}
 
   get-metadata:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
@@ -109,7 +109,7 @@ jobs:
     needs:
       [publish-github-release]
     if: ${{ github.event.inputs.incrementPatch == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -31,7 +31,7 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
       - name: Install VirtoCommerce.GlobalTool
         uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Install VirtoCommerce.GlobalTool
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -26,7 +26,7 @@ jobs:
       envPAT: ${{ secrets.REPO_TOKEN }}
 
   get-metadata:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
@@ -44,7 +44,7 @@ jobs:
   # The push can't move into the cross-repo publish-github.yml (job_workflow_ref mismatch — #6/#9).
   publish-nuget:
     needs: [build, test, get-metadata]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
@@ -109,7 +109,7 @@ jobs:
     needs:
       [publish-github-release]
     if: ${{ github.event.inputs.incrementPatch == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -113,6 +113,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        # Don't keep the runner's GITHUB_TOKEN extraheader: it outranks the global credential
+        # helper below, so the push would use GITHUB_TOKEN instead of REPO_TOKEN.
+        persist-credentials: false
 
     - name: Install VirtoCommerce.GlobalTool
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
           dotnet tool install -g VirtoCommerce.GlobalTool --add-source ./src/VirtoCommerce.Build/artifacts
 
       - name: Set up Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -106,7 +106,7 @@ jobs:
           NUGET_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         id: create_release
         if: ${{ (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') && github.event_name != 'workflow_dispatch' }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # id-token: write lets NuGet/login mint a short-lived OIDC key (Trusted Publishing).
     # contents: write for the GitHub release step.
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       VCBUILD_DISABLE_RELEASE_APPROVAL: "true"
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       VCBUILD_DISABLE_RELEASE_APPROVAL: "true"
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
| Action | Before | After | Breaking changes reviewed |
|---|---|---|---|
| `actions/checkout` | `v3` (3 places), `v7.0.0` SHA (1) | `v7.0.1` | v4/v5 = Node 20/24 runtime (runner ≥ 2.327.1 — fine on GitHub-hosted); v6 stores persisted creds in `$RUNNER_TEMP` (only affects Docker container actions); v7 blocks fork-PR head checkout for `pull_request_target`/`workflow_run` — none of these workflows use those triggers, so no impact |
| `actions/setup-java` | `v3` | `v5.7.0` | v4/v5 are Node 20/24 runtime bumps only; `distribution`/`java-version` inputs unchanged |
| `softprops/action-gh-release` | `v2` | `v3.0.2` | v3 = Node 24 runtime only; `tag_name`/`body`/`draft`/`prerelease`/`make_latest`/`files` all unchanged |
| `actions/cache` | `v6.1.0` SHA | unchanged | already latest |
| `NuGet/login` | `v1.2.0` SHA | unchanged | already latest |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and action version updates only; the increment-version credential change is a targeted fix for which token is used on git push.
> 
> **Overview**
> **Pins and upgrades third-party Actions** across `hotfix.yml`, `main.yml`, and `release.yml`: `actions/checkout` to **v7.0.1** (replacing `v3` tags and an older v7.0.0 SHA), `actions/setup-java` to **v5.7.0** in `main.yml`, and `softprops/action-gh-release` to **v3.0.2** in `main.yml`. References use full commit SHAs for supply-chain pinning.
> 
> In **`hotfix.yml`**, `get-metadata` and `increment-version` move from **`ubuntu-20.04`** to **`ubuntu-latest`**. The **`increment-version`** checkout step adds **`persist-credentials: false`** so pushes after `IncrementPatch` use **`REPO_TOKEN`** via the git credential helper instead of the default `GITHUB_TOKEN` extraheader.
> 
> No application or NuGet publish logic changes; `actions/cache` and `NuGet/login` stay on their existing SHAs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 551c48236986c4ae182bbe29cc178c87d69007ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->